### PR TITLE
Version 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "horario-laboral",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,12 @@
 import { Routes } from '@angular/router';
 
-export const routes: Routes = [];
+export const routes: Routes = [
+  { path: '', redirectTo: 'day', pathMatch: 'full' },
+  {
+    path: 'day',
+    loadComponent: () =>
+      import('./features/day-tracker/day-tracker.component').then(
+        (m) => m.DayTrackerComponent
+      ),
+  },
+];

--- a/src/app/core/interfaces/i-schedule.ts
+++ b/src/app/core/interfaces/i-schedule.ts
@@ -3,18 +3,18 @@ export interface ISchedule {
      * The entry time for the schedule.
      * @type {Date | undefined}
      */
-    entry?: Date;
+    clockInTime?: Date;
 
     /**
      * The exit time for the schedule.
      * @type {Date | undefined}
      */
-    exit?: Date;
+    clockOutTime?: Date;
 
     /**
-     * Calculates the difference in minutes between the entry and exit times.
-     * @returns {number} The difference in minutes between entry and exit.
-     * Returns 0 if either entry or exit is not defined.
+     * Calculates the difference in minutes between the clock-in and clock-out times.
+     * @returns {number} The difference in minutes between clock-in and clock-out.
+     * Returns 0 if either clock-in or clock-out is not defined.
      */
     calculateDifference(): number;
 }

--- a/src/app/core/models/schedule.ts
+++ b/src/app/core/models/schedule.ts
@@ -1,23 +1,23 @@
 import { ISchedule } from "../interfaces/i-schedule";
 
 export class Schedule implements ISchedule {
-    entry?: Date;
-    exit?: Date;
+    clockInTime?: Date;
+    clockOutTime?: Date;
 
-    constructor(entry: Date | undefined, exit: Date | undefined) {
-        this.entry = entry;
-        this.exit = exit;
+    constructor(clockInTime: Date | undefined, clockOutTime: Date | undefined) {
+        this.clockInTime = clockInTime;
+        this.clockOutTime = clockOutTime;
     }
 
     /**
-     * Calculates the difference in minutes between the `entry` and `exit` times.
+     * Calculates the difference in minutes between the `clockInTime` and `clockOutTime`.
      *
-     * @returns {number} The difference in minutes between `entry` and `exit`.
-     * Returns 0 if either `entry` or `exit` is not defined.
+     * @returns {number} The difference in minutes between `clockInTime` and `clockOutTime`.
+     * Returns 0 if either `clockInTime` or `clockOutTime` is not defined.
      */
     calculateDifference(): number {
-        if (!this.entry || !this.exit) return 0;
+        if (!this.clockInTime || !this.clockOutTime) return 0;
 
-        return (this.exit.getTime() - this.entry.getTime()) / 60000;
+        return (this.clockOutTime.getTime() - this.clockInTime.getTime()) / 60000;
     }
 }

--- a/src/app/core/services/week.service.ts
+++ b/src/app/core/services/week.service.ts
@@ -23,6 +23,16 @@ export class WeekService {
   }
 
   /**
+   * Normalizes the given day name by capitalizing the first letter and converting the rest to lowercase.
+   *
+   * @param day - The name of the day to normalize.
+   * @returns The normalized day name with the first letter capitalized and the rest in lowercase.
+   */
+  private normalizeDayName(day: string): string {
+    return day.charAt(0).toUpperCase() + day.slice(1).toLowerCase();
+  }
+
+  /**
    * Determines the current language setting of the user's browser.
    *
    * @remarks
@@ -48,7 +58,7 @@ export class WeekService {
     if (!VALID_DAYS[lang]) {
       throw new Error(`Unsupported language: ${lang}`);
     }
-    return VALID_DAYS[lang]?.includes(day) ?? false;
+    return VALID_DAYS[lang]?.includes(this.normalizeDayName(day)) ?? false;
   }
 
   /**
@@ -157,13 +167,14 @@ export class WeekService {
     if (!this.isValidDay(id)) {
       throw DayError.invalid(id, this.lang);
     }
+    // Normalize the id to match the expected format
     return this.days$.pipe(
       map((days: IDay[]) => {
-        const found = days.find((day) => day.name === id);
+        const found = days.find((day) => day.name === this.normalizeDayName(id));
         if (found) {
           return found;
         }
-        return new Day(id, new Schedule(undefined, undefined));
+        return new Day(this.normalizeDayName(id), new Schedule(undefined, undefined));
       })
     );
   }
@@ -182,7 +193,7 @@ export class WeekService {
     return this.days$.pipe(
       first(),
       map((days: IDay[]) => {
-        const idx = days.findIndex((d) => d.name === day.name);
+        const idx = days.findIndex((d) => d.name === this.normalizeDayName(day.name));
         if (idx !== -1) {
           const updatedDays = [ ...days ];
           updatedDays[idx] = day;

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -15,6 +15,15 @@
         </p-card>
 
         <p-card class="border-round w-8">
+            <div class="flex justify-content-around gap-2 m-3">
+                <div class="flex justify-center align-items-center">
+                    <p-toggleswitch [(ngModel)]="toggled" (onChange)="calculateEstimatedExit()" />
+                    <span class="px-2">Tener en cuenta tiempo acumulado</span>
+                    <i class="pi pi-info-circle"
+                        pTooltip="Se utiliza el tiempo acumulado de días anteriores para calcular la hora de salida estimada."
+                        tooltipPosition="top"></i>
+                </div>
+            </div>
             <div class="flex gap-4 m-3 mb-4 lg:flex-row sm:flex-column">
                 <p-floatlabel variant="on">
                     <p-datepicker [(ngModel)]="clockInTime" [iconDisplay]="'input'" [showIcon]="true" [timeOnly]="true"

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -1,3 +1,5 @@
+<h2 class="text-2xl font-bold text-primary mb-4">{{ today.name | titlecase }}</h2>
+
 <p-button label="Marcar entrada" styleClass="w-full" [raised]="true" size="large" icon="pi pi-arrow-circle-right"
     (click)="clockIn()" [disabled]="!!clockInTime" />
 <p-button label="Marcar salida" styleClass="w-full" [raised]="true" severity="secondary" size="large"

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -1,1 +1,4 @@
-<p>day-tracker works!</p>
+<p-button label="Marcar entrada" styleClass="w-full" [raised]="true" size="large" icon="pi pi-arrow-circle-right"
+    (click)="clockIn()" [disabled]="!!clockInTime" />
+<p-button label="Marcar salida" styleClass="w-full" [raised]="true" severity="secondary" size="large"
+    icon="pi pi-arrow-circle-left" (click)="clockOut()" [disabled]="!clockInTime || (!!clockInTime && !!clockOutTime)" />

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -1,6 +1,46 @@
-<h2 class="text-2xl font-bold text-primary mb-4">{{ today.name | titlecase }}</h2>
+<div class="p-4">
+    <h2 class="text-2xl font-bold text-primary mb-4">{{ today.name | titlecase }}</h2>
 
-<p-button label="Marcar entrada" styleClass="w-full" [raised]="true" size="large" icon="pi pi-arrow-circle-right"
-    (click)="clockIn()" [disabled]="!!clockInTime" />
-<p-button label="Marcar salida" styleClass="w-full" [raised]="true" severity="secondary" size="large"
-    icon="pi pi-arrow-circle-left" (click)="clockOut()" [disabled]="!clockInTime || (!!clockInTime && !!clockOutTime)" />
+    <div class="flex justify-content-around gap-3 mb-4">
+        <p-card class="border-round w-4">
+            <ng-template pTemplate="content">
+                <div class="flex flex-column gap-3 p-3">
+                    <p-button label="Marcar entrada" styleClass="w-full" [raised]="true" size="large"
+                        icon="pi pi-arrow-circle-right" (click)="clockIn()" [disabled]="!!clockInTime" />
+                    <p-button label="Marcar salida" styleClass="w-full" [raised]="true" severity="secondary"
+                        size="large" icon="pi pi-arrow-circle-left" (click)="clockOut()"
+                        [disabled]="!clockInTime || (!!clockInTime && !!clockOutTime)" />
+                </div>
+            </ng-template>
+        </p-card>
+
+        <p-card class="border-round w-8">
+            <div class="flex gap-4 m-3 mb-4 lg:flex-row sm:flex-column">
+                <p-floatlabel variant="on">
+                    <p-datepicker [(ngModel)]="clockInTime" [iconDisplay]="'input'" [showIcon]="true" [timeOnly]="true"
+                        id="entry" [hourFormat]="'24'" showSeconds="true">
+                        <ng-template #inputicon let-clickCallBack="clickCallBack">
+                            <i class="pi pi-clock" (click)="clickCallBack($event)"></i>
+                        </ng-template>
+                    </p-datepicker>
+                    <label for="entry">Entrada</label>
+                </p-floatlabel>
+                <p-floatlabel variant="on">
+                    <p-datepicker [(ngModel)]="clockOutTime" [iconDisplay]="'input'" [showIcon]="true" [timeOnly]="true"
+                        id="exit" [hourFormat]="'24'" showSeconds="true" [disabled]="!clockInTime">
+                        <ng-template #inputicon let-clickCallBack="clickCallBack">
+                            <i class="pi pi-clock" (click)="clickCallBack($event)"></i>
+                        </ng-template>
+                    </p-datepicker>
+                    <label for="exit">Salida</label>
+                </p-floatlabel>
+            </div>
+        </p-card>
+    </div>
+
+    <div class="flex justify-content-center gap-3 m-3 p-3">
+        <p-button label="Limpiar" styleClass="w-full" [raised]="true" severity="secondary" size="large"
+            icon="pi pi-eraser" (click)="clear()" [disabled]="!clockInTime && !clockOutTime" />
+    </div>
+
+</div>

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -1,0 +1,1 @@
+<p>day-tracker works!</p>

--- a/src/app/features/day-tracker/day-tracker.component.html
+++ b/src/app/features/day-tracker/day-tracker.component.html
@@ -16,8 +16,10 @@
 
         <p-card class="border-round w-8">
             <div class="flex justify-content-around gap-2 m-3">
+                <div class="text-right">Hora de salida estimada: <b>{{ estimatedExit ? (estimatedExit | date:'HH:mm:ss')
+                        : '-' }}</b></div>
                 <div class="flex justify-center align-items-center">
-                    <p-toggleswitch [(ngModel)]="toggled" (onChange)="calculateEstimatedExit()" />
+                    <p-toggleswitch [(ngModel)]="toggled" (onChange)="calculateEstimatedExit()" (onBlur)="save()" />
                     <span class="px-2">Tener en cuenta tiempo acumulado</span>
                     <i class="pi pi-info-circle"
                         pTooltip="Se utiliza el tiempo acumulado de días anteriores para calcular la hora de salida estimada."
@@ -27,7 +29,7 @@
             <div class="flex gap-4 m-3 mb-4 lg:flex-row sm:flex-column">
                 <p-floatlabel variant="on">
                     <p-datepicker [(ngModel)]="clockInTime" [iconDisplay]="'input'" [showIcon]="true" [timeOnly]="true"
-                        id="entry" [hourFormat]="'24'" showSeconds="true">
+                        id="entry" [hourFormat]="'24'" showSeconds="true" (ngModelChange)="calculateEstimatedExit()">
                         <ng-template #inputicon let-clickCallBack="clickCallBack">
                             <i class="pi pi-clock" (click)="clickCallBack($event)"></i>
                         </ng-template>
@@ -36,7 +38,7 @@
                 </p-floatlabel>
                 <p-floatlabel variant="on">
                     <p-datepicker [(ngModel)]="clockOutTime" [iconDisplay]="'input'" [showIcon]="true" [timeOnly]="true"
-                        id="exit" [hourFormat]="'24'" showSeconds="true" [disabled]="!clockInTime">
+                        id="exit" [hourFormat]="'24'" showSeconds="true" [disabled]="!clockInTime" (onBlur)="save()">
                         <ng-template #inputicon let-clickCallBack="clickCallBack">
                             <i class="pi pi-clock" (click)="clickCallBack($event)"></i>
                         </ng-template>

--- a/src/app/features/day-tracker/day-tracker.component.spec.ts
+++ b/src/app/features/day-tracker/day-tracker.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DayTrackerComponent } from './day-tracker.component';
+
+describe('DayTrackerComponent', () => {
+  let component: DayTrackerComponent;
+  let fixture: ComponentFixture<DayTrackerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DayTrackerComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(DayTrackerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/day-tracker/day-tracker.component.ts
+++ b/src/app/features/day-tracker/day-tracker.component.ts
@@ -1,0 +1,11 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-day-tracker',
+  imports: [],
+  templateUrl: './day-tracker.component.html',
+  styleUrl: './day-tracker.component.scss'
+})
+export class DayTrackerComponent {
+
+}

--- a/src/app/features/day-tracker/day-tracker.component.ts
+++ b/src/app/features/day-tracker/day-tracker.component.ts
@@ -3,12 +3,20 @@ import { ButtonModule } from 'primeng/button';
 import { WeekService } from '../../core/services/week.service';
 import { IDay } from '../../core/interfaces/i-day';
 import { CommonModule } from '@angular/common';
+import { FloatLabel } from 'primeng/floatlabel';
+import { DatePickerModule } from 'primeng/datepicker';
+import { CardModule } from 'primeng/card';
+import { FormsModule } from '@angular/forms';
 
 @Component({
   selector: 'app-day-tracker',
   imports: [
     CommonModule,
     ButtonModule,
+    FloatLabel,
+    DatePickerModule,
+    CardModule,
+    FormsModule,
   ],
   templateUrl: './day-tracker.component.html',
   styleUrl: './day-tracker.component.scss',
@@ -37,8 +45,12 @@ export class DayTrackerComponent implements OnInit {
           : undefined;
 
         console.log('Today is ' + this.today.name);
-        console.log('Clock-in time is ' + this.clockInTime?.toLocaleTimeString());
-        console.log('Clock-out time is ' + this.clockOutTime?.toLocaleTimeString());
+        console.log(
+          'Clock-in time is ' + this.clockInTime?.toLocaleTimeString()
+        );
+        console.log(
+          'Clock-out time is ' + this.clockOutTime?.toLocaleTimeString()
+        );
       },
       error: (err) => {
         console.error('Error fetching day:', err);
@@ -56,5 +68,11 @@ export class DayTrackerComponent implements OnInit {
     console.log(
       'Clock-out registered ' + this.clockOutTime.toLocaleTimeString()
     );
+  }
+
+  clear() {
+    this.clockInTime = undefined;
+    this.clockOutTime = undefined;
+    console.log('Clock-in and clock-out times cleared');
   }
 }

--- a/src/app/features/day-tracker/day-tracker.component.ts
+++ b/src/app/features/day-tracker/day-tracker.component.ts
@@ -7,16 +7,20 @@ import { FloatLabel } from 'primeng/floatlabel';
 import { DatePickerModule } from 'primeng/datepicker';
 import { CardModule } from 'primeng/card';
 import { FormsModule } from '@angular/forms';
+import { Tooltip } from 'primeng/tooltip';
+import { ToggleSwitch } from 'primeng/toggleswitch';
 
 @Component({
   selector: 'app-day-tracker',
   imports: [
-    CommonModule,
     ButtonModule,
-    FloatLabel,
-    DatePickerModule,
     CardModule,
+    CommonModule,
+    DatePickerModule,
+    FloatLabel,
     FormsModule,
+    ToggleSwitch,
+    Tooltip,
   ],
   templateUrl: './day-tracker.component.html',
   styleUrl: './day-tracker.component.scss',
@@ -25,6 +29,7 @@ export class DayTrackerComponent implements OnInit {
   today!: IDay;
   clockInTime: Date | undefined;
   clockOutTime: Date | undefined;
+  toggled = false;
 
   constructor(private weekService: WeekService) {}
 
@@ -74,5 +79,11 @@ export class DayTrackerComponent implements OnInit {
     this.clockInTime = undefined;
     this.clockOutTime = undefined;
     console.log('Clock-in and clock-out times cleared');
+  }
+
+  calculateEstimatedExit() {
+    if (!this.clockInTime) return;
+
+    console.log("Toggled: ", this.toggled);
   }
 }

--- a/src/app/features/day-tracker/day-tracker.component.ts
+++ b/src/app/features/day-tracker/day-tracker.component.ts
@@ -1,11 +1,25 @@
 import { Component } from '@angular/core';
+import { ButtonModule } from 'primeng/button';
 
 @Component({
   selector: 'app-day-tracker',
-  imports: [],
+  imports: [
+    ButtonModule,
+  ],
   templateUrl: './day-tracker.component.html',
   styleUrl: './day-tracker.component.scss'
 })
 export class DayTrackerComponent {
+  clockInTime: Date | null = null;
+  clockOutTime: Date | null = null;
 
+  clockIn() {
+    this.clockInTime = new Date();
+    console.log('Clock-in registered ' + this.clockInTime.toLocaleTimeString());
+  }
+
+  clockOut() {
+    this.clockOutTime = new Date();
+    console.log('Clock-out registered ' + this.clockOutTime.toLocaleTimeString());
+  }
 }

--- a/src/app/features/day-tracker/day-tracker.component.ts
+++ b/src/app/features/day-tracker/day-tracker.component.ts
@@ -1,17 +1,50 @@
-import { Component } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ButtonModule } from 'primeng/button';
+import { WeekService } from '../../core/services/week.service';
+import { IDay } from '../../core/interfaces/i-day';
+import { CommonModule } from '@angular/common';
 
 @Component({
   selector: 'app-day-tracker',
   imports: [
+    CommonModule,
     ButtonModule,
   ],
   templateUrl: './day-tracker.component.html',
-  styleUrl: './day-tracker.component.scss'
+  styleUrl: './day-tracker.component.scss',
 })
-export class DayTrackerComponent {
-  clockInTime: Date | null = null;
-  clockOutTime: Date | null = null;
+export class DayTrackerComponent implements OnInit {
+  today!: IDay;
+  clockInTime: Date | undefined;
+  clockOutTime: Date | undefined;
+
+  constructor(private weekService: WeekService) {}
+
+  ngOnInit() {
+    const today = new Date('2025-06-23').toLocaleDateString('es-AR', {
+      //const today = new Date("2025-06-23").toLocaleDateString('en-US', {
+      weekday: 'long',
+    });
+
+    this.weekService.getDayById(today).subscribe({
+      next: (day) => {
+        this.today = day;
+        this.clockInTime = day.schedule.clockInTime
+          ? new Date(day.schedule.clockInTime)
+          : undefined;
+        this.clockOutTime = day.schedule.clockOutTime
+          ? new Date(day.schedule.clockOutTime)
+          : undefined;
+
+        console.log('Today is ' + this.today.name);
+        console.log('Clock-in time is ' + this.clockInTime?.toLocaleTimeString());
+        console.log('Clock-out time is ' + this.clockOutTime?.toLocaleTimeString());
+      },
+      error: (err) => {
+        console.error('Error fetching day:', err);
+      },
+    });
+  }
 
   clockIn() {
     this.clockInTime = new Date();
@@ -20,6 +53,8 @@ export class DayTrackerComponent {
 
   clockOut() {
     this.clockOutTime = new Date();
-    console.log('Clock-out registered ' + this.clockOutTime.toLocaleTimeString());
+    console.log(
+      'Clock-out registered ' + this.clockOutTime.toLocaleTimeString()
+    );
   }
 }


### PR DESCRIPTION
# Feature

## Description

This pull request introduces the `DayTrackerComponent`, a presentational component responsible for displaying, managing, and interacting with daily time tracking entries. The implementation covers:

- **Dynamic UI Display** for tracking a single day's schedule, including clock-in and estimated clock-out times.
- **Integration with WeekService** to update a specific day's schedule on user input.
- **Estimated Exit Time Calculation** based on the selected clock-in time and the preferred workday duration from `WorkdayService`.
- **Time Selection UI** using `p-datepicker` for accurate hour, minute, and second control.
- **Field-level Change Detection**: recalculates estimated exit when the user updates the clock-in field.

## Tests
Unit tests for `DayTrackerComponent` are pending

## Task
Refer to the Notion task: [DayTrackerComponent Implementation](https://www.notion.so/DayTrackerComponent-base-2187345d7dcf80a6b2b7e10ef777a1cd)
